### PR TITLE
feat: show total file size in status bar (fixes #18)

### DIFF
--- a/src/ddhx.d
+++ b/src/ddhx.d
@@ -2057,13 +2057,15 @@ void update_status(Session *session)
     else // Regular status bar
     {
         address.change(session.rc.address_type);
-        
-        msg = cast(string)sformat(g_messagebuf, "%c %s | %3s | %8s | %s",
+        ElementText buf2 = void;
+
+        msg = cast(string)sformat(g_messagebuf, "%c %s | %3s | %8s | %s / %s",
             session.editor.edited() ? '*' : ' ',
             writingModeToString(session.rc.writemode),
             dataTypeToString(session.rc.data_type),
             charsetID(session.rc.charset),
-            address.textual(buf0, session.position_cursor, 8));
+            address.textual(buf0, session.position_cursor, 8),
+            formatFileSize(buf2, session.editor.size()));
     }
     
     // Attempt to fit the new message on screen

--- a/src/ddhx.d
+++ b/src/ddhx.d
@@ -2057,15 +2057,13 @@ void update_status(Session *session)
     else // Regular status bar
     {
         address.change(session.rc.address_type);
-        ElementText buf2 = void;
 
-        msg = cast(string)sformat(g_messagebuf, "%c %s | %3s | %8s | %s / %s",
+        msg = cast(string)sformat(g_messagebuf, "%c %s | %3s | %8s | %s",
             session.editor.edited() ? '*' : ' ',
             writingModeToString(session.rc.writemode),
             dataTypeToString(session.rc.data_type),
             charsetID(session.rc.charset),
-            address.textual(buf0, session.position_cursor, 8),
-            formatFileSize(buf2, session.editor.size()));
+            address.textual(buf0, session.position_cursor, 8));
     }
     
     // Attempt to fit the new message on screen
@@ -2081,12 +2079,23 @@ void update_status(Session *session)
     }
     else // message fits on screen
     {
-        terminalWrite(msg.ptr, msglen);
-        
-        // Pad to end of screen with spaces
+        // Right-align file size if there is room
+        ElementText buf2 = void;
+        string sizestr = formatFileSize(buf2, session.editor.size());
+        int sizelen = cast(int)sizestr.length;
         int rem = cols - msglen;
-        if (rem > 0)
-            terminalWriteChar(' ', rem);
+        if (rem >= sizelen + 1) // enough room: left msg, spaces, size flush-right
+        {
+            terminalWrite(msg.ptr, msglen);
+            terminalWriteChar(' ', rem - sizelen);
+            terminalWrite(sizestr.ptr, sizelen);
+        }
+        else // not enough room: just pad with spaces as before
+        {
+            terminalWrite(msg.ptr, msglen);
+            if (rem > 0)
+                terminalWriteChar(' ', rem);
+        }
     }
 }
 

--- a/src/formatting.d
+++ b/src/formatting.d
@@ -759,3 +759,14 @@ unittest
     assert(input.format     == "225");
     assert(input.data       == [ 0x95 ]);
 }
+
+string formatFileSize(ref ElementText buf, long size) {
+    if (size < 1024)
+        return cast(string)sformat(buf, "%d B", size);
+    else if (size < 1024 * 1024)
+        return cast(string)sformat(buf, "%.1f KiB", cast(double)size / 1024.0);
+    else if (size < 1024L * 1024 * 1024)
+        return cast(string)sformat(buf, "%.1f MiB", cast(double)size / (1024.0 * 1024));
+    else
+        return cast(string)sformat(buf, "%.1f GiB", cast(double)size / (1024.0 * 1024 * 1024));
+}


### PR DESCRIPTION
Implements #18 — adds the document's total size to the regular status bar display.

## Changes

**`src/formatting.d`** — new `formatFileSize` helper:
- Formats a `long` byte count as a compact human-readable string
- Uses IEC binary prefixes: `B`, `KiB`, `MiB`, `GiB`
- Writes into an `ElementText` buffer (no heap allocation)

**`src/ddhx.d`** — updated `update_status`:
- Adds `buf2` for the size string
- Appends `/ <size>` to the regular (non-selection, non-message) status line

## Result

Before:
```
 OVR | x8 | ascii | 6c
```

After:
```
 OVR | x8 | ascii | 6c / 1.5 MiB
```

The cursor offset and file size together make it easy to see progress through a file at a glance.